### PR TITLE
Add backend connection events and User Stats

### DIFF
--- a/wavedash/WavedashConstants.gd
+++ b/wavedash/WavedashConstants.gd
@@ -15,6 +15,9 @@ const JS_EVENT_LOBBY_DATA_UPDATED = "LobbyDataUpdated"
 const JS_EVENT_P2P_CONNECTION_ESTABLISHED = "P2PConnectionEstablished"
 const JS_EVENT_P2P_CONNECTION_FAILED = "P2PConnectionFailed"
 const JS_EVENT_P2P_PEER_DISCONNECTED = "P2PPeerDisconnected"
+const JS_EVENT_BACKEND_CONNECTED = "BackendConnected"
+const JS_EVENT_BACKEND_RECONNECTING = "BackendReconnecting"
+const JS_EVENT_BACKEND_DISCONNECTED = "BackendDisconnected"
 
 
 # Platform Types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add backend connection events and user stats/achievements APIs, plus avoid duplicate lobby_joined emissions.
> 
> - **Events**:
>   - Add backend connection event constants in `WavedashConstants.gd`: `JS_EVENT_BACKEND_CONNECTED`, `JS_EVENT_BACKEND_RECONNECTING`, `JS_EVENT_BACKEND_DISCONNECTED`.
>   - Handle backend events in `WavedashSDK.gd` and emit signals: `backend_connected`, `backend_reconnecting`, `backend_disconnected`.
> - **User Stats & Achievements API**:
>   - Add methods: `request_stats()`, `set_stat_int(stat_name, val, store_now)`, `get_stat_int(stat_name)`, `set_achievement(ach_name)`, `get_achievement(ach_name)`.
>   - Add callback `_on_request_stats_result_gd` and signal `current_stats_received`.
> - **Lobby**:
>   - Stop emitting `lobby_joined` in `_on_lobby_joined_gd` to prevent duplicates; rely on JS event dispatch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30f168224f6badca4e521325bb6f9ab13e30d9fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->