### PR TITLE
P2p improvements

### DIFF
--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -320,7 +320,7 @@ func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 		return []
 	
 	var messages: Array[Dictionary] = []
-	var raw_messages: PackedByteArray = JavaScriptBridge.js_buffer_to_packed_byte_array(WavedashJS.drainChannelToBuffer(channel))
+	var raw_messages: PackedByteArray = JavaScriptBridge.js_buffer_to_packed_byte_array(WavedashJS.drainP2PChannelToBuffer(channel))
 	var read_offset = 0
 	while read_offset < raw_messages.size():
 		var message_length = raw_messages[read_offset] | (raw_messages[read_offset + 1] << 8) | (raw_messages[read_offset + 2] << 16) | (raw_messages[read_offset + 3] << 24)

--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -290,7 +290,7 @@ func send_p2p_message(target_user_id: String, payload: PackedByteArray, channel:
 		return WavedashJS.sendP2PMessage(target_user_id, channel, reliable, js_buffer, payload_size)
 
 # Read P2P messages from the incoming queue for a specific channel
-# Deprecated, use receive_all_p2p_messages_on_channel instead
+# Use drain_p2p_channel instead for better performance
 func receive_p2p_messages_on_channel(channel: int, max_messages: int = 32) -> Array[Dictionary]:
 	if OS.get_name() != Constants.PLATFORM_WEB or not WavedashJS:
 		return []

--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -315,7 +315,7 @@ func receive_p2p_messages_on_channel(channel: int, max_messages: int = 32) -> Ar
 	return messages
 
 # Read all P2P messages from the incoming queue for a specific channel
-func receive_all_p2p_messages_on_channel(channel: int) -> Array[Dictionary]:
+func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 	if OS.get_name() != Constants.PLATFORM_WEB or not WavedashJS:
 		return []
 	


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves P2P messaging performance and adds a batched read API.
> 
> - Switches `send_p2p_message` from base64 strings to a pre-allocated JS `ArrayBuffer`, copying bytes and passing `(buffer, payload_size)` to JS (`broadcastP2PMessage`/`sendP2PMessage`); adds max-payload check and drops oversized messages
> - Adds `drain_p2p_channel(channel)` to read all queued messages from a length-prefixed JS buffer and decode them; recommends using this over `receive_p2p_messages_on_channel`
> - Logging tweaks: convert empty payload print to `push_warning` and add warnings for buffer overruns; minor comment cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b285d371207eb35d05d994541b58ed31391091f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->