### PR TITLE
P2P error handling

### DIFF
--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -322,7 +322,8 @@ func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 	var messages: Array[Dictionary] = []
 	var raw_messages: PackedByteArray = JavaScriptBridge.js_buffer_to_packed_byte_array(WavedashJS.drainP2PChannelToBuffer(channel))
 	var read_offset = 0
-	while read_offset < raw_messages.size():
+
+	while read_offset + 4 <= raw_messages.size():
 		var message_length = raw_messages[read_offset] | (raw_messages[read_offset + 1] << 8) | (raw_messages[read_offset + 2] << 16) | (raw_messages[read_offset + 3] << 24)
 		read_offset += 4
 		if read_offset + message_length > raw_messages.size():
@@ -330,7 +331,12 @@ func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 			break
 		var message = raw_messages.slice(read_offset, read_offset + message_length)
 		read_offset += message_length
-		messages.append(_decode_p2p_packet(message))
+		var decoded: Dictionary = _decode_p2p_packet(message)
+		if decoded:
+			messages.append(decoded)
+		else:
+			push_warning("P2P message is malformed, dropping message")
+			break
 	
 	return messages
 

--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -336,7 +336,7 @@ func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 			messages.append(decoded)
 		else:
 			push_warning("P2P message is malformed, dropping message")
-			break
+			continue
 	
 	return messages
 


### PR DESCRIPTION
Handle edge cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of P2P message draining on web.
> 
> - Adjusts `drain_p2p_channel` loop to `while read_offset + 4 <= raw_messages.size()` to avoid reading incomplete length headers
> - Validates decoded packets before appending; drops malformed messages and logs warnings instead of returning empty/invalid entries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68df872c753ca1c8123603687d204a70367a47fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->