### PR TITLE
Handle Leave+Join race condition

### DIFF
--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -329,7 +329,8 @@ func _on_lobby_left_gd(args):
 	var response_json: String = args[0] if args.size() > 0 else null
 	var response: Dictionary = JSON.parse_string(response_json) if response_json else {}
 	print("[WavedashSDK] Lobby left: ", response)
-	if response.get("success", false):
+	# Only clear cache if we left the lobby we're currently in (not if we already joined a new one)
+	if response.get("success", false) and response.get("data", "") == cached_lobby_id:
 		cached_lobby_id = ""
 		cached_lobby_host_id = ""
 	lobby_left.emit(response)

--- a/wavedash/plugin.cfg
+++ b/wavedash/plugin.cfg
@@ -3,5 +3,5 @@
 name="WavedashGodot"
 description="SDK for integrating Wavedash services in Godot WebGL builds. Requires Godot 4.5 or higher."
 author="Wavedash"
-version="1.0.1"
+version="1.0.2"
 script="WavedashPlugin.gd"


### PR DESCRIPTION
Only clear lobby id if it's the lobby we're currently in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale state from a leave/join race by tightening cache invalidation logic.
> 
> - Update `_on_lobby_left_gd` to clear `cached_lobby_id`/`cached_lobby_host_id` only if the left lobby matches the currently cached lobby
> - Bump plugin version to `1.0.2` in `plugin.cfg`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37b154e842ee1c0868c9dc98cfd48ed8c3c0bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->