### PR TITLE
lobby_joined still emits on join failure

### DIFF
--- a/wavedash/WavedashSDK.gd
+++ b/wavedash/WavedashSDK.gd
@@ -414,12 +414,18 @@ func _dispatch_js_event(args):
 			# Reset lobby host, might have changed when users shuffled
 			cached_lobby_host_id = ""
 			lobby_users_updated.emit(data)
+		# All lobby join flows land here
+		# 1. create_lobby success -> LOBBY_JOINED with success=true
+		# 2. join_lobby success -> LOBBY_JOINED with success=true
+		# 3. External join (ie invite link) -> LOBBY_JOINED with success=true
+		# 4. join_lobby failure -> LOBBY_JOINED with success=false
 		Constants.JS_EVENT_LOBBY_JOINED:
 			var data = JSON.parse_string(payload)
 			print("[WavedashSDK] Lobby joined: ", payload)
-			# Enriched signal payload: { lobbyId, hostId, users, metadata }
-			cached_lobby_id = data.get("lobbyId", "")
-			cached_lobby_host_id = data.get("hostId", "")
+			# Payload: { success, lobbyId, hostId?, users?, metadata?, message? }
+			if data.get("success", false):
+				cached_lobby_id = data.get("lobbyId", "")
+				cached_lobby_host_id = data.get("hostId", "")
 			lobby_joined.emit(data)
 		Constants.JS_EVENT_LOBBY_KICKED:
 			var data = JSON.parse_string(payload)

--- a/wavedash/plugin.cfg
+++ b/wavedash/plugin.cfg
@@ -3,5 +3,5 @@
 name="WavedashGodot"
 description="SDK for integrating Wavedash services in Godot WebGL builds. Requires Godot 4.5 or higher."
 author="Wavedash"
-version="1.0.2"
+version="1.0.3"
 script="WavedashPlugin.gd"


### PR DESCRIPTION
lobby_joined signal handles all flows
create -> lobby_joined with success true
join -> lobby_joined with success true
external join (invite link) -> lobby_joined with success true
game calls join_lobby and it fails -> lobby_joined with success false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures lobby join signals cover all flows, including failures, and avoids caching invalid lobby state.
> 
> - Routes all join paths through `JS_EVENT_LOBBY_JOINED`; always emits `lobby_joined` with `{ success, ... }`, including on join failures
> - Only updates `cached_lobby_id` and `cached_lobby_host_id` when `success` is true to prevent stale cache
> - Bumps plugin version to `1.0.3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2a62aeab3c770b56187a21a8ac9a351c36c9c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->