### PR TITLE
Fix call for Godot 4.0

### DIFF
--- a/addons/wavedash/WavedashSDK.gd
+++ b/addons/wavedash/WavedashSDK.gd
@@ -596,7 +596,7 @@ func drain_p2p_channel(channel: int) -> Array[Dictionary]:
 	var messages: Array[Dictionary] = []
 	var raw_messages: PackedByteArray
 	if _has_js_buffer_transfer:
-		raw_messages = JavaScriptBridge.js_buffer_to_packed_byte_array(WavedashJS.drainP2PChannelToBuffer(channel))
+		raw_messages = JavaScriptBridge.call("js_buffer_to_packed_byte_array", WavedashJS.drainP2PChannelToBuffer(channel))
 	else:
 		raw_messages = _js_eval_to_packed_byte_array("WavedashJS.drainP2PChannelToBuffer(%d)" % channel)
 	if raw_messages.is_empty():

--- a/addons/wavedash/plugin.cfg
+++ b/addons/wavedash/plugin.cfg
@@ -3,5 +3,5 @@
 name="WavedashGodot"
 description="SDK for integrating Wavedash services in Godot Web builds. Requires Godot 4.0 or higher."
 author="Wavedash"
-version="1.1.1"
+version="1.1.2"
 script="WavedashPlugin.gd"


### PR DESCRIPTION
JavaScriptBridge.js_buffer_to_packed_byte_array is gated by a compatibility check at runtime but Godot 4.0 won't compile with the call still in the SDK
Replace with `.call` so Godot 4.0 compiles